### PR TITLE
Fix duplicate output of non-issue-attached items.

### DIFF
--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -175,7 +175,7 @@ def construct_releases(entries, app):
             # Handle rare-but-valid non-issue-attached line items, which are
             # always bugs. (They are their own description.)
             if not isinstance(focus, issue):
-                focus = issue(type_='bug', nodelist=[focus], backported=False, major=False, description=[focus])
+                focus = issue(type_='bug', nodelist=[focus], backported=False, major=False, description=[])
             else:
                 focus.attributes['description'] = rest
             if focus.type == 'bug':


### PR DESCRIPTION
Maybe I'm wrong but it looks like a simple entry like:

```
- Fix important bug
```

should be possible.

If such an entry is exists it's added as a bug but the text of the item is added twice. This pull request fixes this.
