### PR TITLE
Generate no links by setting ticket number to 0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,8 @@ Mimic the format seen `in Fabric's changelog
       backporting to bugfix releases; will show up in both release types.
     * ``major``: Given on bug issues to denote inclusion in feature, instead
       of bugfix, releases.
+    * If ``number`` is ``0`` no issue link will be generated. You can use this
+      for items without a related issue.
 
 * Regular Sphinx content may be given after issue roles and will be preserved
   as-is when rendering. For example, in ``:bug:`123` Fixed a bug, thanks

--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -32,14 +32,18 @@ def issues_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     May give a 'ticket number' of '<number> backported' to indicate a
     backported feature or support ticket. This extra info will be stripped out
     prior to parsing. May also give 'major' in the same vein, implying the bug
-    was a major bug released in a feature release.
+    was a major bug released in a feature release. May give a 'ticket number'
+    of 0 to generate no hyperlink.
     """
     # Old-style 'just the issue link' behavior
     issue_no, _, ported = utils.unescape(text).partition(' ')
     # Lol @ access back to Sphinx
     config = inliner.document.settings.env.app.config
-    ref = config.releases_issue_uri % issue_no
-    link = nodes.reference(rawtext, '#' + issue_no, refuri=ref, **options)
+    if issue_no != '0':
+        ref = config.releases_issue_uri % issue_no
+        link = nodes.reference(rawtext, '#' + issue_no, refuri=ref, **options)
+    else:
+        link = None
     # Additional 'new-style changelog' stuff
     if name in issue_types:
         nodelist = issue_nodelist(name, link)


### PR DESCRIPTION
This is a new approach to solve the problem with changelog entries having no issue. It is an updated version of @hynek's pull request #1. I know you were not happy about the hack. So why do I create an updated pull request?
- AFAIK it's not possible to have roles in docutils that have no or empty arguments. So it won't be possible to have a role with an optional ticket number, like you proposed in TODO.
- Optional options would be possible with directives. But as you wrote in TODO there is the downside of getting very huge entries compared to what we have now. And I agree that the current list of items is as simple as it can and should be.
- Line items without an issue role have problems: You can't set the `major` keyword and therefore they go always into bugfix releases - even if you wanted something different!

If this pull request looks like a good solution for you, you can reject my other pull request #3 because this solution totally fits my needs.
