### PR TITLE
Fix link to Fabric's rendered changelog.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -97,7 +97,7 @@ Then build your docs; in the rendered output, ``changelog.html`` should show
 issues grouped by release, as per the above rules. Examples: `Releases' own
 rendered changelog
 <http://releases.readthedocs.org/en/latest/changelog.html>`_, `Fabric's
-rendered changelog <http://docs.fabfile.org/en/latest/changelog.html>`_.
+rendered changelog <http://www.fabfile.org/changelog.html>`_.
 
 
 Optional styling additions


### PR DESCRIPTION
http://docs.fabfile.org/en/latest/changelog.html does not exist.