### PR TITLE
Added support to have comments in the changelog file

### DIFF
--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -335,6 +335,11 @@ def construct_releases(entries, app):
     issues = {}
 
     for obj in reversed(entries):
+
+        # Skip comments
+        if isinstance(obj[0], (unicode, str)):
+            continue
+
         # Issue object is always found in obj (LI) index 0 (first, often only
         # P) and is the 1st item within that (index 0 again).
         # Preserve all other contents of 'obj'.

--- a/releases/_version.py
+++ b/releases/_version.py
@@ -1,2 +1,2 @@
 __version_info__ = (0, 7, 0)
-__version__ = '.'.join(map(str, __version_info__))
+__version__ = '.'.join(map(str, __version_info__)) + '_1'

--- a/tests/changelog.py
+++ b/tests/changelog.py
@@ -334,6 +334,14 @@ class releases(Spec):
         cl = _changelog2dict(cl)
         assert len(cl['1.0.1']) == 2
 
+    def comments_are_not_parsed(self):
+        cl = _releases(('.. This is a comment ',))
+        cl = _changelog2dict(cl)
+        assert len(cl['1.0.0']) == 0
+
+
+
+
 
 def _obj2name(obj):
     cls = obj if isinstance(obj, type) else obj.__class__
@@ -495,3 +503,5 @@ class nodes(Spec):
         _expect_type(para[6], reference)
         eq_(para[6].astext(), '#5')
         assert 'Support' in para[4].astext()
+
+


### PR DESCRIPTION
Trying to use comments in the `changelog.rst` file would produce the following error

```
Exception occurred:
  File "R:\dev\git\platform_tooling\python_starter\venv\doc\lib\site-packages\releases\__init__.py", line 341, in construct_releases
    focus = obj[0].pop(0)
AttributeError: 'unicode' object has no attribute 'pop'
```

Here is a trace of the initial test without fix

```
Traceback (most recent call last):
  File "F:\bin\Python\278\Lib\unittest\case.py", line 329, in run
    testMethod()
  File "R:\dev\experiments\releases\venv\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "R:\dev\experiments\releases\tests\changelog.py", line 338, in comments_are_not_parsed
    cl = _releases(('.. This is a comment ',))
  File "R:\dev\experiments\releases\tests\changelog.py", line 131, in _releases
    return construct_releases(_release_list(*entries), app)
  File "r:\dev\experiments\releases\releases\__init__.py", line 345, in construct_releases
    focus = obj[0].pop(0)
AttributeError: 'str' object has no attribute 'pop'
```

This pull request aims to fix this issue.


