### PR TITLE
Added support to have comments in the changelog file

### DIFF
--- a/integration/_support/vanilla/changelog.rst
+++ b/integration/_support/vanilla/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+.. This is a comment
+
 * :release:`1.0.1 <2014-01-02>`
 * :bug:`1` Fix a bug.
 * :release:`1.0.0 <2014-01-01>`

--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -417,7 +417,7 @@ def construct_nodes(releases):
 class BulletListVisitor(nodes.NodeVisitor):
 
     def __init__(self, document):
-        docutils.nodes.NodeVisitor.__init__(self, document)
+        nodes.NodeVisitor.__init__(self, document)
         self.changelog = None
 
     def visit_bullet_list(self, node):

--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -414,13 +414,33 @@ def construct_nodes(releases):
     return result
 
 
+class BulletListVisitor(nodes.NodeVisitor):
+
+    def __init__(self, document):
+        docutils.nodes.NodeVisitor.__init__(self, document)
+        self.changelog = None
+
+    def visit_bullet_list(self, node):
+        # find the first one
+        if not self.changelog:
+            self.changelog = node
+
+    def unknown_visit(self, node):
+        pass
+
+
 def generate_changelog(app, doctree):
     if app.env.docname != app.config.releases_document_name:
         return
     # Second item inside main document is the 'modern' changelog bullet-list
     # object, whose children are the nodes we care about.
     source = doctree[0]
-    changelog = source.children.pop(1)
+
+    # Find the first bullet-list node
+    changelog_visitor = BulletListVisitor(doctree)
+    source.walk(changelog_visitor)
+    changelog = changelog_visitor.changelog
+
     # Walk + parse into release mapping
     releases = construct_releases(changelog.children, app)
     # Construct new set of nodes to replace the old, and we're done

--- a/tasks.py
+++ b/tasks.py
@@ -7,10 +7,13 @@ from invoke import run
 from invoke import task
 
 
-@task()
-def integration_tests():
+@task(help={
+    'pty': "Whether to run tests under a pseudo-tty",
+})
+def integration_tests(pty=True):
     """Runs integration tests."""
-    run('inv test -o --tests=integration')
+    cmd = 'inv test -o --tests=integration'
+    run(cmd + ('' if pty else ' --no-pty'), pty=pty)
 
 
 ns = Collection(test, integration_tests, release, docs)

--- a/tests/changelog.py
+++ b/tests/changelog.py
@@ -2,12 +2,11 @@ from tempfile import mkdtemp
 from shutil import rmtree
 
 import six
-from spec import Spec, skip, eq_, raises
+from spec import Spec, eq_, raises
 from mock import Mock
 from docutils.nodes import (
-    reference, bullet_list, list_item, title, raw, paragraph, Text, section,
+    reference, bullet_list, list_item, raw, paragraph, Text,
 )
-from docutils.utils import new_document
 from sphinx.application import Sphinx
 import sphinx
 
@@ -18,7 +17,6 @@ from releases import (
     release_role,
     construct_releases,
     construct_nodes,
-    generate_changelog,
 )
 from releases import setup as releases_setup # avoid unittest crap
 


### PR DESCRIPTION
Trying to use comments in the `changelog.rst` file would produce the following error

```
Exception occurred:
  File "R:\dev\git\platform_tooling\python_starter\venv\doc\lib\site-packages\releases\__init__.py", line 341, in construct_releases
    focus = obj[0].pop(0)
AttributeError: 'unicode' object has no attribute 'pop'
```

This pull request aims to fix this issue by finding the first bullet_list item instead of assuming it will be the first element in the page.


