### PR TITLE
fix crash when using sphinx > 1.3.4

### DIFF
--- a/releases/models.py
+++ b/releases/models.py
@@ -30,6 +30,10 @@ class Issue(nodes.Element):
     def line(self):
         return self.get('line', None)
 
+    @line.setter
+    def line(self, value):
+        self['line'] = value
+        
     def __repr__(self):
         flag = ''
         if self.backported:


### PR DESCRIPTION
Probably caused by:
sphinx-doc/sphinx@6dc7ca0234638436f3decfb85990613e69f7809f