### PR TITLE
Add `releases_future_release_uri` config

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Add a configuration to change the link for unreleased changes
 * :bug:`53` Tweak newly-updated models so bugfix items prior to an initial
   release are considered 'major bugs' so they get rolled into that initial
   release (instead of causing a ``ValueError``).

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,6 +26,13 @@ Specifically:
           (If only one is configured, the other link type will continue using
           ``releases_github_path``.)
 
+        * If your unreleased changes live in a different location than your existing
+          releases, set ``releases_future_release_uri`` separately from ``releases_release_uri``.
+          This option *does not* accept a ``%s`` substitution.
+          This setting can also be used to change the branch linked to by unreleased changes.
+          (E.g. ``releases_release_uri = "https://github.com/fabric/fabric/releases/tag/%s"`` and
+          ``releases_future_release_uri = "https://github.com/fabric/fabric/tree/develop"``)
+
     * See `Fabric's docs/conf.py
       <https://github.com/fabric/fabric/blob/4afd33e971f1c6831cc33fd3228013f7484fbe35/docs/conf.py#L31>`_
       for an example.
@@ -60,7 +67,7 @@ Specifically:
       will not be given a hyperlink.
 
 * Issue roles are of the form ``:type:`number[ keyword]```. Specifically:
-  
+
     * ``number`` is used to generate the link to the actual issue in your issue
       tracker (going by the ``releases_issue_uri`` option). It's used for both
       the link target & (part of) the link text.

--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -119,7 +119,9 @@ def release_nodes(text, slug, date, config):
     # title and give it these HTML attributes during render time) so...fuckit.
     # We were already doing fully raw elements elsewhere anyway. And who cares
     # about a PDF of a changelog? :x
-    if config.releases_release_uri:
+    if slug == 'master' and config.releases_future_release_uri:
+        uri = config.releases_future_release_uri
+    elif config.releases_release_uri:
         # TODO: % vs .format()
         uri = config.releases_release_uri % slug
     elif config.releases_github_path:
@@ -180,7 +182,7 @@ def append_unreleased_entries(app, lines, releases):
                 # TODO: should link to master for newest family and...what
                 # exactly, for the others? Expectation isn't necessarily to
                 # have a branch per family? Or is there? Maybe there must be..
-                'master', 
+                'master',
                 None,
                 app.config
             )]
@@ -541,6 +543,10 @@ def setup(app):
     # Release-tag base URI setting: releases_release_uri
     # E.g. 'https://github.com/fabric/fabric/tree/'
     app.add_config_value(name='releases_release_uri', default=None,
+        rebuild='html')
+    # Future Release-tag base URI setting: releases_future_release_uri
+    # E.g. 'https://github.com/fabric/fabric/tree/develop/'
+    app.add_config_value(name='releases_future_release_uri', default=None,
         rebuild='html')
     # Convenience Github version of above
     app.add_config_value(name='releases_github_path', default=None,


### PR DESCRIPTION
Scenario 1:
- Your releases are not kept in branches but instead are in git tags, so `releases_release_uri = 'https://github.com/you/project/releases/tag/v%s'`
- Your unreleased changes are not in a tag, but on branch `master`! So the automatic link to `https://github.com/you/project/releases/tag/vmaster` is bad.

Scenario 2:
- Your releases are kept in branches, so `releases_release_uri` can be the default
- Your unreleased changes are not on `master` but are on `develop`, so the default link to `https://github.com/you/project/tree/master` is bad.

This pull request solves both of these problems by adding the `releases_future_release_uri` config, allowing a custom URI to be set for "faux-releases" separately from normal releases.

I have tested this with my own project and have attempted to run your test suite, but I am not 100% sure I did that correctly, so the running of tests on your end would be appreciated.