### PR TITLE
Report version number to Sphinx

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Report extension version to Sphinx.
 * :release:`1.2.1 <2016-07-25>`
 * :support:`51 backported` Modernize release management so PyPI trove
   classifiers are more accurate, wheel archives are universal instead of Python

--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -8,6 +8,7 @@ import six
 
 from .models import Issue, ISSUE_TYPES, Release, Version, Spec
 from .line_manager import LineManager
+from ._version import __version__
 
 
 def _log(txt, config):
@@ -635,3 +636,6 @@ def setup(app):
     app.add_role('release', release_role)
     # Hook in our changelog transmutation at appropriate step
     app.connect('doctree-read', generate_changelog)
+
+    # identifies the version of our extension
+    return {'version': __version__}


### PR DESCRIPTION
In particular, the version number will show up in the Sphinx log. So instead of:

```
# Sphinx version: 1.3
[...]
# Loaded extensions:
#   alabaster (0.7.9) from c:\tmp\releases-multiple\env\lib\site-packages\alabaster\__init__.py
#   releases (unknown version) from c:\tmp\releases-multiple\env\lib\site-packages\releases\__init__.py
[...]
```

you get:

```
# Sphinx version: 1.3
[...]
# Loaded extensions:
#   alabaster (0.7.9) from c:\tmp\releases-multiple\env\lib\site-packages\alabaster\__init__.py
#   releases (1.2.1) from c:\tmp\releases-multiple\env\lib\site-packages\releases\__init__.py
[...]
```
