### PR TITLE
Remove upper-bound on required Sphinx version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email='jeff@bitprophet.org',
     url='https://github.com/bitprophet/releases',
     packages=['releases'],
-    install_requires=['semantic_version<3.0', 'sphinx>=1.3,<1.5'],
+    install_requires=['semantic_version<3.0', 'sphinx>=1.3'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The current `setup.py` requires Sphinx from the 1.3.x and 1.4.x lines. In practice, *releases* seems to generally work find with newer versions of Sphinx as well, with broken compatibility being treated as a bug (c.f. #66, #67). The current `setup.py` also causes weird bugs from time-to-time with newer version of Sphinx where Python will complain that the wrong version of Sphinx is installed.