### PR TITLE
Rename [wheel] section to [bdist_wheel] as the former is legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ exclude = docs,.git,build,dist
 ignore = E124,E125,E128,E261,E301,E302,E303
 max-line-length = 79
 
-[wheel]
+[bdist_wheel]
 universal = 1


### PR DESCRIPTION
For additional details, see:

https://github.com/pypa/wheel/blob/3dc261abc98a5e43bc7fcf5783d080aaf8f9f0cf/wheel/bdist_wheel.py#L127-L133

http://pythonwheels.com/