### PR TITLE
Add the feature_uri option to integrate PR's and the like

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,6 +26,9 @@ Specifically:
           (If only one is configured, the other link type will continue using
           ``releases_github_path``.)
 
+        * Aditionally you can set the `releases_feautre_uri` which
+          will then be used for the `:feature:` role. This is useful,
+          if your feature additions coincide with pull requests.
     * See `Fabric's docs/conf.py
       <https://github.com/fabric/fabric/blob/4afd33e971f1c6831cc33fd3228013f7484fbe35/docs/conf.py#L31>`_
       for an example.

--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -76,7 +76,9 @@ def issues_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     config = inliner.document.settings.env.app.config
     if issue_no not in ('-', '0'):
         ref = None
-        if config.releases_issue_uri:
+        if name == 'feature' and config.releases_feature_uri:
+            ref = config.releases_feature_uri % issue_no
+        elif config.releases_issue_uri:
             # TODO: deal with % vs .format()
             ref = config.releases_issue_uri % issue_no
         elif config.releases_github_path:
@@ -617,6 +619,9 @@ def setup(app):
         # Issue base URI setting: releases_issue_uri
         # E.g. 'https://github.com/fabric/fabric/issues/'
         ('issue_uri', None),
+        # Feature base URI setting: releases_feature_uri
+        # E.g. 'https://github.com/fabric/fabric/pulls/'
+        ('feature_uri', None),
         # Release-tag base URI setting: releases_release_uri
         # E.g. 'https://github.com/fabric/fabric/tree/'
         ('release_uri', None),

--- a/releases/util.py
+++ b/releases/util.py
@@ -289,6 +289,7 @@ def make_app(**kwargs):
     config = {
         'releases_release_uri': 'foo_%s',
         'releases_issue_uri': 'bar_%s',
+        'releases_feature_uri': 'baz_%s',
         'releases_debug': False,
         'master_doc': 'index',
     }


### PR DESCRIPTION
This adds a `request_feature_uri` option. Which will, if specified, take the place of `request_issue_uri` for the `:feature:` role.
This is useful to integrate pull requests.