### PR TITLE
Fix compatibility with >=python-semanticversion-2.7.0

### DIFF
--- a/releases/__init__.py
+++ b/releases/__init__.py
@@ -426,7 +426,7 @@ def handle_upcoming_major_release(entries, manager):
     # to the line manager!
     for obj in next_releases:
         # TODO: update when Release gets tied closer w/ Version
-        version = Version(obj.number)
+        version = Version.coerce(obj.number)
         if version.minor == 0 and version.patch == 0:
             manager.add_family(obj.family)
 


### PR DESCRIPTION
## Context
The recent versions of python-semanticversion made changes to private
APIs, removing the interaction between `Version(x, partial=True)` and
`Spec()` (`partial=True` was designed for implementing the `Spec` class
only).

This breaks `releases`, has mentioned in #84 and #85; it has also been reported as affecting twine's doc building (https://github.com/pypa/twine/issues/492).

The attached patch switches to the recommended usage of python-semanticversion (whose docs are still lacking in that regard, sorry :disappointed:), while keeping all tests green - both with updated and old python-semanticversion releases.

## Implementation notes

The code used `Version(..., partial=True)` to exclude ranges of version whose major
component didn't match a bugfix/issue range; the code went akin to:

    Version('1', partial=True) in Spec('>=1.0')

This no longer works; this patch changes that behaviour to exclude
families where no actual release matches the bugfix/issue range - this
should be more accurate.

The patch also uses `Version.coerce`, the intended API to manage
non semver-compliant version strings.

## Compatibility

The patch has been tested with both python-semanticversion==2.6.0 and
python-semanticversion==2.8.1; it can be included to an upgraded version
of `releases` even if users haven't yet upgraded python-semanticversion.